### PR TITLE
Remove port from start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "node -r dotenv/config app.js",
-    "start": "PORT=3001 node app.js"
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove port from start script to avoid overriding port set by environment variable.